### PR TITLE
Eth as unit and print onchain bal

### DIFF
--- a/alice.yaml
+++ b/alice.yaml
@@ -18,7 +18,7 @@ chain:
   url: ws://127.0.0.1:8545
   adjudicator: 0xDc4A7e107aD6dBDA1870df34d70B51796BBd1335
   assetholder: 0xb051EAD0C6CC2f568166F8fEC4f07511B88678bA
-  deployTimeout: 30s
+  txTimeout: 30s
 
 log:
   level: warn

--- a/bob.yaml
+++ b/bob.yaml
@@ -18,7 +18,7 @@ chain:
   url: ws://127.0.0.1:8545
   adjudicator: deploy
   assetHolder: deploy
-  deployTimeout: 30s
+  txTimeout: 30s
 
 log:
   level: warn

--- a/cmd/demo/config.go
+++ b/cmd/demo/config.go
@@ -40,7 +40,7 @@ type nodeConfig struct {
 }
 
 type chainConfig struct {
-	DeployTimeout time.Duration
+	TxTimeout time.Duration
 
 	Adjudicator string
 	Assetholder string

--- a/cmd/demo/node.go
+++ b/cmd/demo/node.go
@@ -187,7 +187,7 @@ func (n *node) PrintConfig() error {
 // deployAdjudicator deploys the Adjudicator to the blockchain and returns its address
 // or an error.
 func deployAdjudicator(cb echannel.ContractBackend) (common.Address, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), config.Chain.DeployTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), config.Chain.TxTimeout)
 	defer cancel()
 	adjAddr, err := echannel.DeployAdjudicator(ctx, cb)
 	return adjAddr, errors.WithMessage(err, "deploying eth adjudicator")
@@ -196,7 +196,7 @@ func deployAdjudicator(cb echannel.ContractBackend) (common.Address, error) {
 // deployAsset deploys the Assetholder to the blockchain and returns its address
 // or an error. Needs an Adjudicator address as second argument.
 func deployAsset(cb echannel.ContractBackend, adjudicator common.Address) (common.Address, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), config.Chain.DeployTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), config.Chain.TxTimeout)
 	defer cancel()
 	asset, err := echannel.DeployETHAssetholder(ctx, cb, adjudicator)
 	return asset, errors.WithMessage(err, "deploying eth assetholder")
@@ -460,7 +460,7 @@ func (n *node) Info(args []string) error {
 	defer n.mtx.Unlock()
 	n.log.Traceln("Info...")
 
-	ctx, cancel := context.WithTimeout(context.Background(), config.Chain.DeployTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), config.Chain.TxTimeout)
 	defer cancel()
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', tabwriter.Debug)
 	fmt.Fprintf(w, "Peer\tPhase\tVersion\tMy Ξ\tPeer Ξ\tMy On-Chain Ξ\tPeer On-Chain Ξ\t\n")

--- a/cmd/demo/payment.go
+++ b/cmd/demo/payment.go
@@ -74,8 +74,10 @@ func (ch *paymentChannel) sendUpdate(update func(*channel.State), desc string) e
 		ActorIdx: ch.Idx(),
 	})
 	ch.log.Debugf("Sent update: %s, err: %v", desc, err)
+
 	if balChanged {
-		fmt.Println("💸 Sent payment. New balance:", state.Allocation.Balances[0])
+		bals := weiToEther(state.Allocation.Balances[0]...)
+		fmt.Printf("💰 Sent payment. New balance: [My: %v Ξ, Peer: %v Ξ]\n", bals[ch.Idx()], bals[1-ch.Idx()])
 	}
 	if err == nil {
 		ch.lastState = state
@@ -107,7 +109,8 @@ func (ch *paymentChannel) Handle(update client.ChannelUpdate, res *client.Update
 	}
 
 	if balChanged {
-		fmt.Println("\n💰 Received payment. New balance:", update.State.Allocation.Balances[0])
+		bals := weiToEther(update.State.Allocation.Balances[0]...)
+		fmt.Printf("\n💰 Received payment. New balance: [My: %v Ξ, Peer: %v Ξ]\n", bals[ch.Idx()], bals[1-ch.Idx()])
 	}
 	if update.State.IsFinal {
 		ch.log.Trace("Calling onFinal handler for paymentChannel")


### PR DESCRIPTION
- Use ethereum as unit for command line values (input and output). Computations in the app are still done in wei to retain accuracy.
- Add onchain balance to the output of info command.