### PR TITLE
:bug:, :recycle: [cmd, demo] fix error on cmd help

### DIFF
--- a/cmd/demo/config.go
+++ b/cmd/demo/config.go
@@ -70,6 +70,17 @@ func GetConfig() *Config {
 
 // SetConfig called by viper when the config file was parsed
 func SetConfig() {
+	// Load config files
+	viper.SetConfigFile(flags.cfgFile)
+	if err := viper.ReadInConfig(); err != nil {
+		log.Fatalf("Error reading config file, %s", err)
+	}
+
+	viper.SetConfigFile(flags.cfgNetFile)
+	if err := viper.MergeInConfig(); err != nil {
+		log.Fatalf("Error reading network config file, %s", err)
+	}
+
 	if err := viper.Unmarshal(&config); err != nil {
 		log.Fatal(err)
 	}

--- a/cmd/demo/demo.go
+++ b/cmd/demo/demo.go
@@ -3,12 +3,10 @@
 // perun-eth-demo. Use of this source code is governed by the Apache 2.0
 // license that can be found in the LICENSE file.
 
-package cmd
+package demo
 
 import (
 	"fmt"
-
-	demo "github.com/perun-network/perun-eth-demo/cmd/demo"
 
 	prompt "github.com/c-bata/go-prompt"
 	"github.com/spf13/cobra"
@@ -25,21 +23,34 @@ var demoCmd = &cobra.Command{
 	Run: runDemo,
 }
 
-var testAPI bool
+// CommandLineFlags contains the command line flags.
+type CommandLineFlags struct {
+	testAPIEnabled bool
+	cfgFile        string
+	cfgNetFile     string
+}
+
+var flags CommandLineFlags
 
 func init() {
-	rootCmd.AddCommand(demoCmd)
-	demoCmd.PersistentFlags().BoolVar(&testAPI, "test-api", false, "Expose testing API at 8080")
-	demoCmd.PersistentFlags().BoolVar(&demo.GetConfig().Node.PersistenceEnabled, "persistence", false, "Enables the persistence")
-	demoCmd.PersistentFlags().StringVar(&demo.GetConfig().SecretKey, "sk", "", "ETH Secret Key")
+	demoCmd.PersistentFlags().StringVar(&flags.cfgFile, "config", "config.yaml", "General config file")
+	demoCmd.PersistentFlags().StringVar(&flags.cfgNetFile, "network", "network.yaml", "Network config file")
+	demoCmd.PersistentFlags().BoolVar(&flags.testAPIEnabled, "test-api", false, "Expose testing API at 8080")
+	demoCmd.PersistentFlags().BoolVar(&GetConfig().Node.PersistenceEnabled, "persistence", false, "Enables the persistence")
+	demoCmd.PersistentFlags().StringVar(&GetConfig().SecretKey, "sk", "", "ETH Secret Key")
 	viper.BindPFlag("secretkey", demoCmd.PersistentFlags().Lookup("sk"))
+}
+
+// GetDemoCmd exposes demoCmd so that it can be used as a sub-command by another cobra command instance.
+func GetDemoCmd() *cobra.Command {
+	return demoCmd
 }
 
 // runDemo is executed everytime the program is started with the `demo` sub-command.
 func runDemo(c *cobra.Command, args []string) {
-	demo.Setup()
-	if testAPI {
-		demo.StartTestAPI()
+	Setup()
+	if flags.testAPIEnabled {
+		StartTestAPI()
 	}
 	p := prompt.New(
 		executor,
@@ -56,7 +67,7 @@ func completer(prompt.Document) []prompt.Suggest {
 
 // executor wraps the demo executor to print error messages.
 func executor(in string) {
-	if err := demo.Executor(in); err != nil {
+	if err := Executor(in); err != nil {
 		fmt.Println("\033[0;33m⚡\033[0m", err)
 	}
 }

--- a/cmd/demo/demo_test.go
+++ b/cmd/demo/demo_test.go
@@ -5,7 +5,7 @@
 
 // +build on_chain_eth_test
 
-package cmd_test
+package demo_test
 
 import (
 	"fmt"
@@ -25,12 +25,12 @@ var (
 )
 
 func TestNodes(t *testing.T) {
-	alice, _, err := expect.Spawn("go run ../main.go demo --config ../alice.yaml --network ../network.yaml --log-level trace --test-api true --log-file alice.log", -1)
+	alice, _, err := expect.Spawn("go run ../../main.go demo --config ../../alice.yaml --network ../../network.yaml --log-level trace --test-api true --log-file alice.log", -1)
 	require.NoError(t, err)
 	defer alice.Close()
 	time.Sleep(time.Second * 2)
 
-	bob, _, err := expect.Spawn("go run ../main.go demo --config ../bob.yaml --network ../network.yaml --log-level trace --log-file bob.log", -1)
+	bob, _, err := expect.Spawn("go run ../../main.go demo --config ../../bob.yaml --network ../../network.yaml --log-level trace --log-file bob.log", -1)
 	require.NoError(t, err)
 	defer bob.Close()
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -12,42 +12,25 @@ import (
 
 	"perun.network/go-perun/log"
 
+	"github.com/perun-network/perun-eth-demo/cmd/demo"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
 
 var rootCmd = &cobra.Command{
-	Use:              "perun",
-	Short:            "Perun Network umbrella executable",
-	Long:             "Umbrella project for demonstrators and tests of the Perun Project.",
+	Use:              "perun-eth-demo",
+	Short:            "Perun State Channels Demo",
+	Long:             "Demonstrator for the Perun state channel framework using the Ethereum backend.",
 	PersistentPreRun: runRoot,
 }
 
-var cfgFile, cfgNetFile string
-
 func init() {
-	cobra.OnInitialize(initConfig)
-	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "config.yaml", "General config file")
-	rootCmd.PersistentFlags().StringVar(&cfgNetFile, "network", "network.yaml", "Network config file")
 	rootCmd.PersistentFlags().StringVar(&logConfig.Level, "log-level", "warn", "Logrus level")
 	viper.BindPFlag("log.level", rootCmd.PersistentFlags().Lookup("log-level"))
 	rootCmd.PersistentFlags().StringVar(&logConfig.File, "log-file", "", "log file")
 	viper.BindPFlag("log.file", rootCmd.PersistentFlags().Lookup("log-file"))
-}
 
-// initConfig reads the config and sets the loglevel.
-// The demo configuration will be parsed in the
-func initConfig() {
-	// Load config files
-	viper.SetConfigFile(cfgFile)
-	if err := viper.ReadInConfig(); err != nil {
-		log.Fatalf("Error reading config file, %s", err)
-	}
-
-	viper.SetConfigFile(cfgNetFile)
-	if err := viper.MergeInConfig(); err != nil {
-		log.Fatalf("Error reading network config file, %s", err)
-	}
+	rootCmd.AddCommand(demo.GetDemoCmd())
 }
 
 func runRoot(c *cobra.Command, args []string) {


### PR DESCRIPTION
- fixed error caused by trying to read config files when executing cli help
- moved demo command definition to package demo to allow for accessing cli variables

Fixes #15 

The problem was that when running the help command, it already tried to load the config files, where "config.yaml" is not present. My first idea was to load the config files only when running the demo command. However, for that I needed to make the config file parameters available to the package demo. Unfortunately, the demo command definition for some reason was in package cmd. To make it work, I refactored the demo command definition and its tests into package demo (where I think it belongs anyways).