### PR TITLE
:lock: validate contracts instantiated from network address

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,18 +41,20 @@ configuration for Alice and Bob is provided in file `network.yaml`.
 In a first terminal, start a `ganache-cli` development blockchain, prefunding
 the accounts of `Alice` and `Bob`:
 ```sh
-ganache-cli --account="0x7d51a817ee07c3f28581c47a5072142193337fdca4d7911e58c5af2d03895d1a,100000000000000000000000" --account="0x6aeeb7f09e757baa9d3935a042c3d0d46a2eda19e9b676283dce4eaf32e29dc9,100000000000000000000000"
+ganache-cli --account="0x6aeeb7f09e757baa9d3935a042c3d0d46a2eda19e9b676283dce4eaf32e29dc9,100000000000000000000000" --account="0x7d51a817ee07c3f28581c47a5072142193337fdca4d7911e58c5af2d03895d1a,100000000000000000000000"
 ```
 
-In a second and third terminal, start the nodes of Alice and Bob with
+In a second terminal, start the node of Alice with
 ```sh
 ./perun-eth-demo demo --config alice.yaml
 ```
-and
+and in a third terminal, start the node of Bob with
 ```sh
 ./perun-eth-demo demo --config bob.yaml
 ```
-You can see two transaction in the ganache terminal, which correspond to the
+It is important to start Alice first as she is the one deploying the channel contracts.
+Bob validates the contracts at startup and quits if the contracts have not been deployed correctly.
+You can see two transactions in the ganache terminal corresponding to the
 deployment of the `AssetHolder` and `Adjudicator` contracts.
 
 Once both CLIs are running, e.g. in Alice's terminal, connect to bob with

--- a/alice.yaml
+++ b/alice.yaml
@@ -1,5 +1,5 @@
 alias: alice
-secretKey: 0x7d51a817ee07c3f28581c47a5072142193337fdca4d7911e58c5af2d03895d1a
+secretKey: 0x6aeeb7f09e757baa9d3935a042c3d0d46a2eda19e9b676283dce4eaf32e29dc9
 walletPath: /tmp/alice_wallet
 
 channel:
@@ -18,8 +18,8 @@ node:
 
 chain:
   url: ws://127.0.0.1:8545
-  adjudicator: 0xDc4A7e107aD6dBDA1870df34d70B51796BBd1335
-  assetholder: 0xb051EAD0C6CC2f568166F8fEC4f07511B88678bA
+  adjudicator: deploy
+  assetholder: deploy
   txTimeout: 30s
 
 log:

--- a/bob.yaml
+++ b/bob.yaml
@@ -1,5 +1,5 @@
 alias: bob
-secretKey: 0x6aeeb7f09e757baa9d3935a042c3d0d46a2eda19e9b676283dce4eaf32e29dc9
+secretKey: 0x7d51a817ee07c3f28581c47a5072142193337fdca4d7911e58c5af2d03895d1a
 walletPath: /tmp/bob_wallet
 
 channel:
@@ -18,8 +18,8 @@ node:
 
 chain:
   url: ws://127.0.0.1:8545
-  adjudicator: deploy
-  assetHolder: deploy
+  adjudicator: 0xDc4A7e107aD6dBDA1870df34d70B51796BBd1335
+  assetholder: 0xb051EAD0C6CC2f568166F8fEC4f07511B88678bA
   txTimeout: 30s
 
 log:

--- a/cmd/demo/node_setup.go
+++ b/cmd/demo/node_setup.go
@@ -113,12 +113,21 @@ func (n *node) setupContracts() (err error) {
 		if err != nil {
 			return
 		}
+		fmt.Println("💭 Adjudicator contract deployed")
 	} else {
 		tmpAdj, err := strToAddress(config.Chain.Adjudicator)
 		if err != nil {
 			return err
 		}
 		adjAddr = ewallet.AsEthAddr(tmpAdj)
+
+		ctx, cancel := context.WithTimeout(context.Background(), config.Chain.TxTimeout)
+		defer cancel()
+		if err := echannel.ValidateAdjudicator(ctx, n.cb, adjAddr); err != nil {
+			return errors.WithMessage(err, "validating adjudicator contract")
+		}
+
+		fmt.Println("💭 Adjudicator contract validated")
 	}
 
 	if config.Chain.Assetholder == "deploy" {
@@ -126,12 +135,21 @@ func (n *node) setupContracts() (err error) {
 		if err != nil {
 			return
 		}
+		fmt.Println("💭 Asset holder contract deployed")
 	} else {
 		tmpAsset, err := strToAddress(config.Chain.Assetholder)
 		if err != nil {
 			return err
 		}
 		assAddr = ewallet.AsEthAddr(tmpAsset)
+
+		ctx, cancel := context.WithTimeout(context.Background(), config.Chain.TxTimeout)
+		defer cancel()
+		if err := echannel.ValidateAssetHolderETH(ctx, n.cb, assAddr, adjAddr); err != nil {
+			return errors.WithMessage(err, "validating asset holder contract")
+		}
+
+		fmt.Println("💭 Asset holder contract validated")
 	}
 	n.adjAddr = adjAddr
 	n.assetAddr = assAddr

--- a/network.yaml
+++ b/network.yaml
@@ -1,10 +1,10 @@
 peers:
   alice:
-    perunID: 0xA298Fc05bccff341f340a11FffA30567a00e651f
+    perunID: 0x05e71027e7d3bd6261de7634cf50F0e2142067C4
     hostname: 127.0.0.1
     port: 5751
 
   bob:
-    perunID: 0x05e71027e7d3bd6261de7634cf50F0e2142067C4
+    perunID: 0xA298Fc05bccff341f340a11FffA30567a00e651f
     hostname: 127.0.0.1
     port: 5750


### PR DESCRIPTION
Fixes #11 

added contract validation on node setup. needed to change alice.yaml and bob.yaml so that alice, who is run first in the walkthrough, is deploying the contracts and bob is validating them correctly.