### PR TITLE
[ci] Log CI Unit Test errors.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,5 +71,5 @@ jobs:
       run: |
         docker run --name chain --rm --net=host trufflesuite/ganache-cli -m "pistol kiwi shrug future ozone ostrich match remove crucial oblige cream critic" --block-time 5 -e 1000 &
         sleep 5
-        go test -timeout 120s -cover ./...
+        go test -timeout 120s -cover ./... || (cat cmd/demo/alice.log cmd/demo/bob.log; exit 1)
         docker stop chain


### PR DESCRIPTION
Alice and Bob are started in separate executables. If one of them
outputs an error message, we currently do not see it in the CI.
This commit outputs the log files in case the test fails.
